### PR TITLE
add cef commandlineargs support

### DIFF
--- a/CefSharp.OutOfProcess.BrowserProcess/Program.cs
+++ b/CefSharp.OutOfProcess.BrowserProcess/Program.cs
@@ -16,12 +16,11 @@ namespace CefSharp.OutOfProcess.BrowserProcess
         {
             Cef.EnableHighDPISupport();
 
-            Debugger.Launch();
+            //Debugger.Launch();
 
             var parentProcessId = int.Parse(CommandLineArgsParser.GetArgumentValue(args, "--parentProcessId"));
 
             var parentProcess = Process.GetProcessById(parentProcessId);
-
 
             var settings = new CefSettings()
             {

--- a/CefSharp.OutOfProcess.BrowserProcess/Program.cs
+++ b/CefSharp.OutOfProcess.BrowserProcess/Program.cs
@@ -29,13 +29,7 @@ namespace CefSharp.OutOfProcess.BrowserProcess
                 MultiThreadedMessageLoop = false
             };
 
-            foreach (var arg in args)
-            {
-                List<string> splitted = arg.Split('=').ToList();
-                var key = splitted.First().Substring(2);
-                var value = splitted.Count == 1 ? string.Empty : splitted.Last();
-                AddArg(settings, key, value);
-            }
+            AddArgs(settings, args);
 
             var browserProcessHandler = new BrowserProcessHandler(parentProcessId);
 
@@ -76,7 +70,18 @@ namespace CefSharp.OutOfProcess.BrowserProcess
             return 0;
         }
 
-        private static void AddArg(CefSettingsBase settings, string key, string value)
+        private static void AddArgs(CefSettings settings, IEnumerable<string> args)
+        {
+            foreach (var arg in args)
+            {
+                List<string> splitted = arg.Split('=').ToList();
+                var key = splitted.First().Substring(2);
+                var value = splitted.Count == 1 ? string.Empty : splitted.Last();
+                AddArg(settings, key, value);
+            }
+        }
+
+        private static void AddArg(CefSettings settings, string key, string value)
         {
             switch (key)
             {

--- a/CefSharp.OutOfProcess.Core/OutOfProcessHost.cs
+++ b/CefSharp.OutOfProcess.Core/OutOfProcessHost.cs
@@ -254,9 +254,9 @@ namespace CefSharp.OutOfProcess
 
             var host = new OutOfProcessHost(fullPath, cachePath, cefCommandLineArgs);
 
-            host.Init();
+            host.Init();            
 
             return host.InitializedTask;
-        }
+        }        
     }
 }

--- a/CefSharp.OutOfProcess.Core/OutOfProcessHost.cs
+++ b/CefSharp.OutOfProcess.Core/OutOfProcessHost.cs
@@ -34,11 +34,11 @@ namespace CefSharp.OutOfProcess
         private ConcurrentDictionary<int, IChromiumWebBrowserInternal> _browsers = new ConcurrentDictionary<int, IChromiumWebBrowserInternal>();
         private TaskCompletionSource<OutOfProcessHost> _processInitialized = new TaskCompletionSource<OutOfProcessHost>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        private OutOfProcessHost(string outOfProcessHostExePath, string cachePath = null, IEnumerable<string> userargs = null)
+        private OutOfProcessHost(string outOfProcessHostExePath, string cachePath = null, IEnumerable<string> cefCommandLineArgs = null)
         {
             _outofProcessHostExePath = outOfProcessHostExePath;
             _cachePath = cachePath;
-            _cefCommandLineArgs = userargs;
+            _cefCommandLineArgs = cefCommandLineArgs;
         }
 
         /// <summary>


### PR DESCRIPTION
Add the ability to set an optional list of cef command line args when creating a browser in the `OutOfProcessHost`. 

In our case we use this to setup the proxy in the out of process browser