### PR TITLE
update BrowserProcess packages and target framework

### DIFF
--- a/CefSharp.OutOfProcess.BrowserProcess/CefSharp.OutOfProcess.BrowserProcess.csproj
+++ b/CefSharp.OutOfProcess.BrowserProcess/CefSharp.OutOfProcess.BrowserProcess.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net462</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net462;net7.0</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <SelfContained>false</SelfContained>
@@ -13,17 +13,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="PInvoke.Kernel32" Version="0.7.104" />
-    <PackageReference Include="PInvoke.User32" Version="0.7.104" />
-    <PackageReference Include="StreamJsonRpc" Version="2.11.35" />
+    <PackageReference Include="PInvoke.Kernel32" Version="0.7.124" />
+    <PackageReference Include="PInvoke.User32" Version="0.7.124" />
+    <PackageReference Include="StreamJsonRpc" Version="2.13.33" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-    <PackageReference Include="CefSharp.Common" Version="102.0.100" />
+    <PackageReference Include="CefSharp.Common" Version="109.1.110" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net462'">
-    <PackageReference Include="CefSharp.Common.NETCore" Version="102.0.100" />
+    <PackageReference Include="CefSharp.Common.NETCore" Version="109.1.110" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CefSharp.OutOfProcess.BrowserProcess/OutOfProcessChromiumWebBrowser.cs
+++ b/CefSharp.OutOfProcess.BrowserProcess/OutOfProcessChromiumWebBrowser.cs
@@ -172,6 +172,12 @@ namespace CefSharp.OutOfProcess.BrowserProcess
         /// </summary>
         /// <value>The drag handler.</value>
         public IDragHandler DragHandler { get; set; }
+
+        /// <summary>
+        /// Implement <see cref="IPermissionHandler" /> and assign to handle events related to permissions.
+        /// </summary>
+        public IPermissionHandler PermissionHandler { get; set; }
+
         /// <summary>
         /// Implement <see cref="IResourceRequestHandlerFactory" /> and control the loading of resources
         /// </summary>


### PR DESCRIPTION
Added net7 target framework. The BrowserProcess is not a library that the user could use to decide which framework to use.